### PR TITLE
Fix broken splits.

### DIFF
--- a/AHatInTime.asl
+++ b/AHatInTime.asl
@@ -84,7 +84,7 @@ start {
 }
 
 split {
-    return (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 && vars.actTimerIsVisible.Current == 1) || vars.timerState.Current == 2;
+    return vars.timePieceCount.Current == vars.timePieceCount.Old + 1;
 }
 
 reset {


### PR DESCRIPTION
Fixed "rumbi factory" not splitting in patch DLC 2.1 and fixed splits happening once per frame after completing The Finale.

[Rumbi Factory example.](https://youtu.be/FNKQ1VYvXUc?t=9425)  
This happens because in that patch the Act Timer is not active for this time rift for some reason (most likely a mistake from GFB).

[Finale splits example.](https://youtu.be/FNKQ1VYvXUc?t=4595) 
This one happens because of the condition "vars.timerState.Current == 2".

Completely unrelated but this is my first time doing a pull request so I hope I didn't make any mistake here.