### PR TITLE
Add many customizable split options and improve load time.

### DIFF
--- a/AHatInTime.asl
+++ b/AHatInTime.asl
@@ -76,7 +76,7 @@ startup {
     settings.Add("splits_tp_std", true, "Seal The Deal", "splits_tp");
     settings.SetToolTip("splits_tp_std", "End of Death Wish Any%.\nOnly works on detected patches.");
     settings.Add("splits_actEntry", false, "Act Entries");
-    settings.SetToolTip("splits_actEntry", "When using undetected patches it will also trigger for time rifts in the spaceship.");
+    settings.SetToolTip("splits_actEntry", "Also for Time Rifts in the spaceship.");
     settings.Add("splits_dwbth", false, "Death Wish Level Back to Hub");
     settings.SetToolTip("splits_dwbth", "Only works on detected patches.");
     settings.CurrentDefaultParent = null;
@@ -465,7 +465,7 @@ split {
                 ||
                 vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && version != "Undetected" && current.chapter == 3 && vars.lastChapter == 5 && settings["splits_tp_std"]  // seal the deal time piece
                 ||
-                vars.gameTimerIsPaused.Old == 1 && vars.gameTimerIsPaused.Current == 0 && (vars.realActTime.Old == 0f || vars.realActTime.Old > vars.realActTime.Current) && settings["splits_actEntry"] && vars.currentRift == "none" && !settings["settings_ILMode"] // act entry
+                vars.gameTimerIsPaused.Old == 1 && vars.gameTimerIsPaused.Current == 0 && (vars.realActTime.Old == 0f || vars.realActTime.Old > vars.realActTime.Current) && settings["splits_actEntry"] && !settings["settings_ILMode"] // act entry or spaceship rift entry
                 ||
                 version != "Undetected" && current.chapter == 97 && old.chapter != 97 && settings["splits_dwbth"]  // death wish back to hub
                 )

--- a/AHatInTime.asl
+++ b/AHatInTime.asl
@@ -1,23 +1,45 @@
-// TODO: cp, cp_pause, cp_pause_pos, decide what to do with pos splits (alpine and slap), test act entries, add all rift splits
+// TODO: wtmt entry, fix alpine multisplits (pos) add all rift splits
+// done: custom tp, delayed tp, act entry (wxcept wtmt), cp, cp_pause, cp_pause_pos, decide what to do with pos splits (alpine and slap),
+// bonus: initial load is much faster now
 
 state("HatinTimeGame", "DLC 2.1") {
+    float x : 0x011BC360, 0x6DC, 0x00, 0x68, 0x51C, 0x80;
+    float y : 0x011BC360, 0x6DC, 0x00, 0x68, 0x51C, 0x84;
+    float z : 0x011BC360, 0x6DC, 0x00, 0x68, 0x51C, 0x88;
+
     int chapter : 0x011E1570, 0x68, 0x108;
     int act : 0x011E1570, 0x68, 0x10C;
+    int checkpoint : 0x011E1570, 0x68, 0x110;
 }
 
 state("HatinTimeGame", "110% Patch") {
+    float x : 0x011F9FE0, 0x6DC, 0x00, 0x68, 0x51C, 0x80;
+    float y : 0x011F9FE0, 0x6DC, 0x00, 0x68, 0x51C, 0x84;
+    float z : 0x011F9FE0, 0x6DC, 0x00, 0x68, 0x51C, 0x88;
+
     int chapter : 0x0121F280, 0x68, 0x108;
     int act : 0x0121F280, 0x68, 0x10C;
+    int checkpoint : 0x0121F280, 0x68, 0x110;
 }
 
 state("HatinTimeGame", "DLC 1.5") {
+    float x : 0x011C27E0, 0x6DC, 0x00, 0x68, 0x2F4, 0x80;
+    float y : 0x011C27E0, 0x6DC, 0x00, 0x68, 0x2F4, 0x84;
+    float z : 0x011C27E0, 0x6DC, 0x00, 0x68, 0x2F4, 0x88;
+
     int chapter: 0x011E7550, 0x68, 0x108;
     int act : 0x011E7550, 0x68, 0x10C;
+    int checkpoint : 0x011E7550, 0x68, 0x110;
 }
 
 state("HatinTimeGame", "Modding") {
+    float x : 0x011229C0, 0x6DC, 0x00, 0x68, 0x508, 0x80;
+    float y : 0x011229C0, 0x6DC, 0x00, 0x68, 0x508, 0x84;
+    float z : 0x011229C0, 0x6DC, 0x00, 0x68, 0x508, 0x88;
+
     int chapter : 0x011475A8, 0x64, 0xF8;
     int act : 0x011475A8, 0x64, 0xFC;
+    int checkpoint : 0x011475A8, 0x64, 0x100;
 }
 
 startup {
@@ -78,21 +100,21 @@ startup {
         for (int i = 1; i <= 7; i++){
             if ((j <= 4) && string.Compare(actNames[j-1, i-1], "") != 0){
                 settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i, true, actNames[j-1, i-1], "manySplits_" + (j == 4 ? 6 : j));
-                settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i + "_entry", false, "Telescope Entry", "manySplits_" + (j == 4 ? 6 : j) + "_" + i);
+                settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i + "_entry", false, "Entry", "manySplits_" + (j == 4 ? 6 : j) + "_" + i);
             }
             else {
                 i = 8;
             }
         }
         if (j == 4 || j == 5 || j == 7){
-            settings.Add("manySplits_" + j + "_entry", false, "Telescope Entry", "manySplits_" + j);
+            settings.Add("manySplits_" + j + "_entry", false, "Entry", "manySplits_" + j);
         }
     }
 
     settings.Add("manySplits_1_1_cp1", false, "Umbrella Fight", "manySplits_1_1");
     settings.Add("manySplits_1_2_cp1", false, "Battle Start", "manySplits_1_2");
     settings.Add("manySplits_1_3_cp1", false, "Scare", "manySplits_1_3");
-    settings.Add("1_4_cp0_pause_pos", false, "Enter HQ", "manySplits_1_4");
+    settings.Add("manySplits_1_4_cp0_pause_pos", false, "Enter HQ", "manySplits_1_4");
     settings.Add("manySplits_1_4_cp1", false, "Vent", "manySplits_1_4");
     settings.Add("manySplits_1_4_cp2", false, "Boss", "manySplits_1_4");
     settings.Add("manySplits_1_6_cp59_pause", false, "Death", "manySplits_1_6");
@@ -112,9 +134,23 @@ startup {
     settings.Add("manySplits_3_4_cp0_pause_pos", false, "Inside Manor", "manySplits_3_4");
     settings.Add("manySplits_3_6_cp1", false, "Fight Start", "manySplits_3_6");
 
-    settings.Add("manySplits_4_99_cp0_pause_pos", false, "Intro End", "manySplits_4");
+    settings.CurrentDefaultParent = "manySplits_4";
+    settings.Add("manySplits_4_99_cp0_pause_pos", false, "Intro End");
     settings.SetToolTip("manySplits_4_99_cp0_pause_pos", "Triggered when going back to hub right after the screen fades to white in the zipline.");
+    settings.Add("4_birdhouse", false, "The Birdhouse Arrival");
+    settings.SetToolTip("4_birdhouse", "Triggered close to the end of the zipline.");
+    settings.Add("4_lava_cake", false, "The Lava Cake Arrival");
+    settings.SetToolTip("4_lava_cake", "Triggered close to the end of the zipline.");
+    settings.Add("4_windmill", false, "The Windmill Arrival");
+    settings.SetToolTip("4_windmill", "Triggered close to the end of the zipline.");
+    settings.Add("4_twilight", false, "The Twilight Bell Arrival");
+    settings.SetToolTip("4_twilight", "Triggered close to the end of the zipline.");
+    settings.Add("4_illness_bh", false, "The Illness Has Spread - Birdhouse Warp");
+    settings.Add("4_illness_wind", false, "The Illness Has Spread - Windmill Warp");
 
+    settings.CurrentDefaultParent = null;
+
+    settings.Add("manySplits_5_slap", false, "Slap", "manySplits_5");
     settings.Add("manySplits_5_1_cp10", false, "Hyper Zone", "manySplits_5");
 
     settings.Add("manySplits_6_1_cp3", false, "Check-in", "manySplits_6_1");
@@ -168,7 +204,7 @@ init {
 
     var ptr = IntPtr.Zero;
 
-    foreach (var page in game.MemoryPages(true)) {
+    foreach (var page in game.MemoryPages(true).Reverse()) {
         // if (page.State == MemPageState.MEM_COMMIT &&
         //     page.Type == MemPageType.MEM_IMAGE &&
         //     page.Protect == MemPageProtect.PAGE_READWRITE
@@ -219,6 +255,24 @@ init {
         vars.realActTime,
         vars.timePieceCount
     };
+
+    // for certain conditions that need hat kid's position to work
+	Func <int, int, bool, float, float, float, bool> ShouldSplitAtThisPos = (int chapter, int act, bool timerChangedState, float x, float y, float z) => {
+	return (chapter == 4 && (act != 4  && settings["4_birdhouse"] && x > -24000f&& x < -23000f&& y > 29000f  && y < 30500f && z > 4000f  && z < 6000f  ||   // birdhouse arrival
+			                 act != 3  && settings["4_lava_cake"] && x > 3000f  && x < 30400f && y > -28500f && y < -27353f&& z > 3200f  && z < 4000f  ||   // lava cake arrival
+			                 act != 13 && settings["4_windmill"] && x > 71600f && x < 72300f && y > 21500f  && y < 22700f && z > 1500f  && z < 2100f   ||   // windmill arrival
+			                 act != 15 && settings["4_twilight"] && x > 4600f  && x < 8700f  && y > 69000f  && y < 70000f && z > 4000f  && z < 5400f   ||   // twilight bell arrival
+			                 settings["4_illness_bh"]   && x > -20000f&& x < -10000f&& y > 45000f  && y < 52500f && z < -9680f                         ||   // illness birdhouse warp
+			                 settings["4_illness_wind"] && x > 38000f && x < 47000f && y > 28000f  && y < 34000f && z < -9680f)                        ||   // illness windmill warp
+            chapter == 5 && settings["manySplits_5_slap"] && x > -38300f && x <-38190f && y > -85000f && y <-84000f && z >-59900f && z <-59000f        ||   // slap (5-1)
+			
+			timerChangedState  &&  (chapter == 1 && settings["manySplits_1_4_cp0_pause_pos"] && x > 3500f  && x < 4500f  && y > -3500f  && y < -3000f && z > 8000f  && z < 9000f    ||   // mafia boss enter HQ (1-4)
+                                    chapter == 2 && settings["manySplits_2_6_cp0_pause_pos"] && x > 5500f  && x < 9500f  && y > 8200f   && y < 12000f && z < 5000f                  ||   // basement boss entry (2-6)
+			                        chapter == 3 && settings["manySplits_3_2_cp0_pause_pos"] && x > 15800f && x < 17000f && y > 10900f  && y < 11900f && z < 2000f                  ||   // inside well (3-2)
+			                        chapter == 3 && settings["manySplits_3_4_cp0_pause_pos"] && x > -28000f&& x < -26000f&& y > 2000f   && y < 3400f  && z > 200f   && z < 1200f    ||   // qvm inside manor (3-4)
+			                        chapter == 4 && settings["manySplits_4_99_cp0_pause_pos"]&& x > 37000f && x < 41000f && y > 47000f  && y < 51000f && z > -14000f&& z < -5000f ));    // alpine intro(4-99)
+	};
+	vars.ShouldSplitAtThisPos = ShouldSplitAtThisPos;
 }
 
 update {
@@ -262,7 +316,15 @@ split {
             (
             (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 || vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0) && (settings["manySplits_" + current.chapter + "_" + current.act + "_tp"] || settings["manySplits_" + current.chapter + "_"])  // custom time pieces
             ||
+            current.checkpoint != old.checkpoint && settings["manySplits_" + current.chapter + "_" + current.act + "_cp" + current.checkpoint] // new checkpoint
+            ||
+            vars.ShouldSplitAtThisPos(current.chapter, current.act, vars.gameTimerIsPaused.Changed, current.x, current.y, current.z) // all position splits
+            ||
             vars.splitInLoadScreen && vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0  // delayed custom time pieces
+            ||
+            vars.realActTime.Current == 0f && vars.realActTime.Old != 0f && (settings["manySplits_" + current.chapter + "_" + current.act + "_entry"] || settings["manySplits_" + current.chapter + "_entry"]) // act entry
+            ||
+            vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0 && settings["manySplits_" + current.chapter + "_" + current.act + "_cp" + current.checkpoint + "_pause"] // paused with certain checkpoint
             )
         )
         )
@@ -270,12 +332,6 @@ split {
             return true;
         }
 
-    // pause screen splits
-    else if (vars.realActTime.Current == 0f && settings["manySplits_" + current.chapter + "_" + current.act + "_entry"]){
-        vars.splitsLock = true;
-        return true;
-    }
-    
     return false;
 }
 

--- a/AHatInTime.asl
+++ b/AHatInTime.asl
@@ -1,8 +1,3 @@
-// TODO: 
-// change illness windmill pos to work with tree slide
-// consider adding list of triggered pos splits
-// consider adding 2 level pos splits? (first pos 1 is touched, then pos 2 triggers a split)
-
 state("HatinTimeGame", "DLC 2.1") {
     float x : 0x011BC360, 0x6DC, 0x00, 0x68, 0x51C, 0x80;
     float y : 0x011BC360, 0x6DC, 0x00, 0x68, 0x51C, 0x84;
@@ -143,16 +138,16 @@ startup {
     settings.Add("manySplits_4_99_entry", false, "Intro Entry");
     settings.Add("manySplits_4_99_cp0_pause_pos", false, "Intro End");
     settings.SetToolTip("manySplits_4_99_cp0_pause_pos", "Triggered when going back to hub right after the screen fades to white in the zipline.");
-    settings.Add("4_birdhouse", false, "The Birdhouse Arrival");
-    settings.SetToolTip("4_birdhouse", "Triggered close to the end of the zipline.");
-    settings.Add("4_lava_cake", false, "The Lava Cake Arrival");
-    settings.SetToolTip("4_lava_cake", "Triggered close to the end of the zipline.");
-    settings.Add("4_windmill", false, "The Windmill Arrival");
-    settings.SetToolTip("4_windmill", "Triggered close to the end of the zipline.");
-    settings.Add("4_twilight", false, "The Twilight Bell Arrival");
-    settings.SetToolTip("4_twilight", "Triggered close to the end of the zipline.");
-    settings.Add("4_illness_bh", false, "The Illness Has Spread - Birdhouse Warp");
-    settings.Add("4_illness_wind", false, "The Illness Has Spread - Windmill Warp");
+    settings.Add("manySplits_pos_40", false, "The Birdhouse Arrival");
+    settings.SetToolTip("manySplits_pos_40", "Triggered close to the end of the zipline.");
+    settings.Add("manySplits_pos_41", false, "The Lava Cake Arrival");
+    settings.SetToolTip("manySplits_pos_41", "Triggered close to the end of the zipline.");
+    settings.Add("manySplits_pos_42", false, "The Windmill Arrival");
+    settings.SetToolTip("manySplits_pos_42", "Triggered close to the end of the zipline.");
+    settings.Add("manySplits_pos_43", false, "The Twilight Bell Arrival");
+    settings.SetToolTip("manySplits_pos_43", "Triggered close to the end of the zipline.");
+    settings.Add("manySplits_pos_44", false, "The Illness Has Spread - Birdhouse Warp");
+    settings.Add("manySplits_pos_45", false, "The Illness Has Spread - Windmill Warp");
 
     settings.CurrentDefaultParent = null;
 
@@ -162,7 +157,7 @@ startup {
     settings.SetToolTip("manySplits_5_1_cp2", "Only recommended for ILs");
     settings.Add("manySplits_5_1_cp3", false, "Big Doors 2", "manySplits_5");
     settings.SetToolTip("manySplits_5_1_cp3", "Only recommended for ILs");
-    settings.Add("manySplits_5_slap", false, "Slap", "manySplits_5");
+    settings.Add("manySplits_pos_5", false, "Slap", "manySplits_5");
     settings.Add("manySplits_5_1_cp10", false, "Hyper Zone", "manySplits_5");
 
     settings.Add("manySplits_6_1_cp3", false, "Check-in", "manySplits_6_1");
@@ -216,10 +211,9 @@ startup {
 
     vars.lastChapter = 0; // used by seal the deal split
     vars.splitInLoadScreen = false;
-    vars.splitsLockTimer = new Stopwatch();
-    vars.splitsLockTimer.Start();
     vars.currentRift = "none"; // indicates the current time rift, none -> not in a rift
     vars.justEnteredRift = false;
+    vars.posSplitKey = 0f; // key for a position split to trigger, 0f -> no key currently in use
 }
 
 init {
@@ -296,23 +290,59 @@ init {
         vars.timePieceCount
     };
 
-    // for certain conditions that need hat kid's position to work
-    Func <int, int, bool, float, float, float, bool> ShouldSplitAtThisPos = (int chapter, int act, bool timerChangedState, float x, float y, float z) => {
-    return(chapter == 4 && (act != 4  && settings["4_birdhouse"] && x > -24000f&& x < -23000f&& y > 29000f  && y < 30500f && z > 4000f  && z < 6000f  ||   // birdhouse arrival
-                            act != 3  && settings["4_lava_cake"] && x > 3000f  && x < 30400f && y > -28500f && y < -27353f&& z > 3200f  && z < 4000f  ||   // lava cake arrival
-                            act != 13 && settings["4_windmill"]  && x > 71600f && x < 72300f && y > 21500f  && y < 22700f && z > 1500f  && z < 2100f  ||   // windmill arrival
-                            act != 15 && settings["4_twilight"]  && x > 4600f  && x < 8700f  && y > 69000f  && y < 70000f && z > 4000f  && z < 5400f  ||   // twilight bell arrival
-                            settings["4_illness_bh"]   && x > -20000f && x < -10000f && y > 45000f  && y < 52500f && z < -9680f                       ||   // illness birdhouse warp
-                            settings["4_illness_wind"] && x > 38000f  && x < 47000f  && y > 28000f  && y < 34000f && z < -9680f)                      ||   // illness windmill warp
-            chapter == 5 && settings["manySplits_5_slap"] && x > -38300f && x <-38190f && y > -85000f && y <-84000f && z >-59900f && z <-59000f       ||   // slap (5-1)
-            
-            timerChangedState  &&  (chapter == 1 && settings["manySplits_1_4_cp0_pause_pos"] && x > 3500f  && x < 4500f  && y > -3500f  && y < -3000f && z > 8000f  && z < 9000f    ||   // mafia boss enter HQ (1-4)
-                                    chapter == 2 && settings["manySplits_2_6_cp0_pause_pos"] && x > 5500f  && x < 9500f  && y > 8200f   && y < 12000f && z < 5000f                  ||   // basement boss entry (2-6)
-                                    chapter == 3 && settings["manySplits_3_2_cp0_pause_pos"] && x > 15800f && x < 17000f && y > 10900f  && y < 11900f && z < 2000f                  ||   // inside well (3-2)
-                                    chapter == 3 && settings["manySplits_3_4_cp0_pause_pos"] && x > -28000f&& x < -26000f&& y > 2000f   && y < 3400f  && z > 200f   && z < 1200f    ||   // qvm inside manor (3-4)
-                                    chapter == 4 && settings["manySplits_4_99_cp0_pause_pos"]&& x > 37000f && x < 41000f && y > 47000f  && y < 51000f && z > -14000f&& z < -5000f ));    // alpine intro (4-99)
+    // volume "keys" that enable the volume split triggers
+    // the main idea is making a volume trigger a split only when hat kid has gone through a certain other volume right before, determined using a key
+    // format of lists: {min x, max x, min y, max y, min z, max z, key for position splits}
+    // -2f: ignored coordinate
+    Dictionary<int, List<List<float>>> posSplitKeysDict = new Dictionary<int, List<List<float>>>();
+
+    List<List<float>> posVolumeKeysChFour = new List<List<float>>();
+    posVolumeKeysChFour.Add (new List<float>() {-11000f, -9000f,  32000f,  34000f,  -1000f, 500f,  40f});  // birdhouse arrival
+    posVolumeKeysChFour.Add (new List<float>() {36500f,  38000f,  -13000f, -11000f, 4500f,  5500f, 41f});  // lava cake arrival
+    posVolumeKeysChFour.Add (new List<float>() {47000f,  49000f,  21000f,  22000f,  1000f,  2500f, 42f});  // windmill arrival
+    posVolumeKeysChFour.Add (new List<float>() {7000f,   8500f,   43000f,  45000,   -1000f, 1000f, 43f});  // twilight bell arrival
+    posVolumeKeysChFour.Add (new List<float>() {-15500f, -14000f, 47400f,  49000f,  -2000f, 0f,    44f});  // illness birdhouse warp
+    posVolumeKeysChFour.Add (new List<float>() {41000f,  42500f,  29000f,  30500f,  2000f,  3500f, 45f});  // illness windmill warp
+    posSplitKeysDict.Add (4, posVolumeKeysChFour);
+
+    List<List<float>> posVolumeKeysChFive = new List<List<float>>();
+    posVolumeKeysChFive.Add (new List<float>() {-30000f, -28000f, -2f, -2f, -2f, -2f, 5f}); // slap (5-1)
+    posSplitKeysDict.Add (5, posVolumeKeysChFive);
+
+    vars.posSplitKeysDict = posSplitKeysDict;
+
+    // position splits that use a key given by the "volume keys" dictionary
+    Dictionary<float, float[]> posSplitsDict = new Dictionary<float, float[]>();
+    posSplitsDict.Add(40f, new float[6] {-24000f,  -23000f, 29000f,   30500f,   4000f,  6000f});    // birdhouse arrival
+    posSplitsDict.Add(41f, new float[6] {3000f,    30400f,  -28500f,  -27353f,  3200f,  4000f});    // lava cake arrival
+    posSplitsDict.Add(42f, new float[6] {71600f,   72300f,  21500f,   22700f,   1500f,  2100f});    // windmill arrival
+    posSplitsDict.Add(43f, new float[6] {4600f,    8700f,   69000f,   70000f,   4000f,  5400f});    // twilight bell arrival
+    posSplitsDict.Add(44f, new float[6] {-2f,      -2f,     -2f,      -2f,      -2f,    -9680f});   // illness birdhouse warp
+    posSplitsDict.Add(45f, new float[6] {-2f,      -2f,     -2f,      -2f,      -2f,    -4230f});   // illness windmill warp
+    posSplitsDict.Add(5f,  new float[6] {-38300f,  -38190f, -85000f,  -84000f,  -2f,    -2f});      // slap (5-1)
+    vars.posSplitsDict = posSplitsDict;
+
+    // positions/volumes that trigger a split when their "volume key" is active
+    Func <float, float, float, float[], bool> ShouldSplitAtThisPos = (float x, float y, float z, float[] position) => {
+        if ((x > position[0] || position[0] == -2f) && (x < position[1] || position[1] == -2f) && 
+            (y > position[2] || position[2] == -2f) && (y < position[3] || position[3] == -2f) && 
+            (z > position[4] || position[4] == -2f) && (z < position[5] || position[5] == -2f)){
+            vars.posSplitKey = 0f;
+            return true;
+            }
+        return false;
     };
     vars.ShouldSplitAtThisPos = ShouldSplitAtThisPos;
+
+    // for certain splits that trigger when the timer is paused/unpaused while hat kid is at a certain position
+    Func <int, float, float, float, bool> ShouldSplitAtThisPosPause = (int chapter, float x, float y, float z) => {
+    return  chapter == 1 && settings["manySplits_1_4_cp0_pause_pos"] && x > 3500f  && x < 4500f  && y > -3500f  && y < -3000f && z > 8000f  && z < 9000f    ||   // enter mafia HQ (1-4)
+            chapter == 2 && settings["manySplits_2_6_cp0_pause_pos"] && x > 5500f  && x < 9500f  && y > 8200f   && y < 12000f && z < 5000f                  ||   // basement boss entry (2-6)
+            chapter == 3 && settings["manySplits_3_2_cp0_pause_pos"] && x > 15800f && x < 17000f && y > 10900f  && y < 11900f && z < 2000f                  ||   // inside well (3-2)
+            chapter == 3 && settings["manySplits_3_4_cp0_pause_pos"] && x > -28000f&& x < -26000f&& y > 2000f   && y < 3400f  && z > 200f   && z < 1200f    ||   // qvm inside manor (3-4)
+            chapter == 4 && settings["manySplits_4_99_cp0_pause_pos"]&& x > 37000f && x < 41000f && y > 47000f  && y < 51000f && z > -14000f&& z < -5000f;       // alpine intro (4-99)
+    };
+    vars.ShouldSplitAtThisPosPause = ShouldSplitAtThisPosPause;
 
     // returns the current rift based on hat kid's position
     Func <int, float, float, float, string> CurrentRiftCheck = (int chapter, float x, float y, float z) => {
@@ -364,56 +394,29 @@ init {
     };
     vars.BackToHubCheck = BackToHubCheck;
 
-
-
-
-
-
-    // borrarrrrrrrrrrrrrrr
-
-    // updates a text component in the layout, also creates it if it doesn't exist
-	Action <string, string> UpdateTextComponent = (string name, string updatedText) => {
-		bool foundComponent = false;
-		foreach (dynamic component in timer.Layout.Components){
-			if (component.GetType().Name != "TextComponent" || component.Settings.Text1 != name) continue;
-			component.Settings.Text2 = updatedText;
-			foundComponent = true;
-			break;
-		}
-		if (!foundComponent) vars.CreateTextComponent(name, updatedText);
-	};
-	vars.UpdateTextComponent = UpdateTextComponent;
-	
-	// creates a text component, used when UpdateTextComponent doens't find the text component requested
-	Action <string, string> CreateTextComponent = (string textLeft, string textRight) => {
-		var textComponentAssembly = Assembly.LoadFrom("Components\\LiveSplit.Text.dll");
-		dynamic textComponent = Activator.CreateInstance(textComponentAssembly.GetType("LiveSplit.UI.Components.TextComponent"), timer);
-		timer.Layout.LayoutComponents.Add(new LiveSplit.UI.Components.LayoutComponent("LiveSplit.Text.dll", textComponent as LiveSplit.UI.Components.IComponent));
-		textComponent.Settings.Text1 = textLeft;
-		textComponent.Settings.Text2 = textRight;
-	};
-	vars.CreateTextComponent = CreateTextComponent;
-
-
 }
 
 update {
     vars.watchers.UpdateAll(game);
+
     if (version != "Undetected"){
         if (current.chapter != old.chapter){
             vars.lastChapter = old.chapter;
         }
+        // delayed time piece split activation
         if ((vars.timePieceCount.Current == vars.timePieceCount.Old + 1 || vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0) && settings["manySplits_" + current.chapter + "_" + current.act + "_tpDelayed"]){
             vars.splitInLoadScreen = true;
         }
+        // actions taken when timer unpauses
         if (vars.gameTimerIsPaused.Current == 0 && vars.gameTimerIsPaused.Old == 1){
             vars.splitInLoadScreen = false;
+            vars.posSplitKey = 0f;
             vars.currentRift = (vars.BackToHubCheck(current.chapter, current.x, current.y, current.z) ? "none" : vars.currentRift);
         }
         if (vars.timerState.Current == 0){
             vars.currentRift = "none";
         }
-        
+
         if (vars.justEnteredRift){
             vars.justEnteredRift = false;
         }
@@ -424,8 +427,17 @@ update {
                 vars.justEnteredRift = true;
             }
         }
+        // position split key detection
+        if (current.chapter == 4 || current.chapter == 5){
+            foreach (var position in vars.posSplitKeysDict[current.chapter]){ 
+                if ((current.x > position[0] || position[0] == -2f) && (current.x < position[1] || position[1] == -2f) && 
+                    (current.y > position[2] || position[2] == -2f) && (current.y < position[3] || position[3] == -2f) && 
+                    (current.z > position[4] || position[4] == -2f) && (current.z < position[5] || position[5] == -2f)){
+                    vars.posSplitKey = position[6];
+                }
+            }
+        }
     }
-    vars.UpdateTextComponent("Rift", vars.currentRift);
 }
 
 start {
@@ -436,57 +448,49 @@ start {
 
 split {
 
-    if (vars.timerState.Current != 0
-        &&
-        settings["splits"] 
+    return  vars.timerState.Current != 0
             &&
-            (
-            vars.timePieceCount.Current == vars.timePieceCount.Old + 1 && settings["splits_tp_new"]  // new time piece
+            settings["splits"] 
+                &&
+                (
+                vars.timePieceCount.Current == vars.timePieceCount.Old + 1 && settings["splits_tp_new"]  // new time piece
+                ||
+                vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && settings["splits_tp_any"]  // any time piece
+                ||
+                vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && version != "Undetected" && current.chapter == 3 && vars.lastChapter == 5 && settings["splits_tp_std"]  // seal the deal
+                ||
+                vars.gameTimerIsPaused.Old == 1 && vars.gameTimerIsPaused.Current == 0 && (vars.realActTime.Current == 0f || vars.realActTime.Old == 0f) && settings["splits_actEntry"] && vars.currentRift == "none" && !settings["settings_ILMode"] // act entry
+                ||
+                version != "Undetected" && current.chapter == 97 && old.chapter != 97 && settings["splits_dwbth"]  // death wish back to hub
+                )
             ||
-            vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && settings["splits_tp_any"]  // any time piece
+            settings["manySplits"] && version != "Undetected" && vars.currentRift == "none"
+                &&
+                (
+                (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 || vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0) && (settings["manySplits_" + current.chapter + "_" + current.act + "_tp"] || settings["manySplits_" + current.chapter + "_tp"])  // custom time pieces
+                ||
+                current.checkpoint != old.checkpoint && settings["manySplits_" + current.chapter + "_" + current.act + "_cp" + current.checkpoint] // new act checkpoint
+                ||
+                vars.posSplitKey != 0f && settings["manySplits_pos_" + vars.posSplitKey.ToString()] && vars.ShouldSplitAtThisPos(current.x, current.y, current.z, vars.posSplitsDict[vars.posSplitKey]) // position splits
+                ||
+                vars.splitInLoadScreen && vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0  // delayed custom time pieces
+                ||
+                vars.realActTime.Old == 0f && vars.gameTimerIsPaused.Current == 0 && vars.gameTimerIsPaused.Old == 1 && !settings["settings_ILMode"] && (settings["manySplits_" + current.chapter + "_" + current.act + "_entry"] || settings["manySplits_" + current.chapter + "_entry"]) // custom act entry
+                ||
+                vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0 && settings["manySplits_" + current.chapter + "_" + current.act + "_cp" + current.checkpoint + "_pause"] // paused with certain checkpoint
+                ||
+                vars.gameTimerIsPaused.Changed && vars.ShouldSplitAtThisPosPause(current.chapter, current.x, current.y, current.z) // position splits when timer is paused / unpaused
+                )
             ||
-            vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && version != "Undetected" && current.chapter == 3 && vars.lastChapter == 5 && settings["splits_tp_std"]  // seal the deal
-            ||
-            vars.gameTimerIsPaused.Old == 1 && vars.gameTimerIsPaused.Current == 0 && (vars.realActTime.Current == 0f || vars.realActTime.Old == 0f) && settings["splits_actEntry"] && vars.currentRift == "none" && !settings["settings_ILMode"] // act entry
-            ||
-            version != "Undetected" && current.chapter == 97 && old.chapter != 97 && settings["splits_dwbth"]  // death wish back to hub
-            )
-        ||
-        settings["manySplits"] && version != "Undetected" && vars.currentRift == "none"
-            &&
-            (
-            (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 || vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0) && (settings["manySplits_" + current.chapter + "_" + current.act + "_tp"] || settings["manySplits_" + current.chapter + "_tp"])  // custom time pieces
-            ||
-            current.checkpoint != old.checkpoint && settings["manySplits_" + current.chapter + "_" + current.act + "_cp" + current.checkpoint] // new act checkpoint
-            ||
-            vars.splitInLoadScreen && vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0  // delayed custom time pieces
-            ||
-            vars.realActTime.Old == 0f && vars.gameTimerIsPaused.Current == 0 && vars.gameTimerIsPaused.Old == 1 && !settings["settings_ILMode"] && (settings["manySplits_" + current.chapter + "_" + current.act + "_entry"] || settings["manySplits_" + current.chapter + "_entry"]) // custom act entry
-            ||
-            vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0 && settings["manySplits_" + current.chapter + "_" + current.act + "_cp" + current.checkpoint + "_pause"] // paused with certain checkpoint
-            )
-        ||
-        settings["manySplits"] && vars.currentRift != "none"
-            &&
-            (
-            (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 || vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0) && (settings[vars.currentRift + "_tp"]) // custom time piece (rifts)
-            ||
-            current.checkpoint > old.checkpoint && settings[vars.currentRift + "_cp"] // new purple rift checkpoint
-            ||
-            vars.justEnteredRift && settings[vars.currentRift + "_entry"] && !settings["settings_ILMode"] // rift entry
-            )
-        )
-    {
-        return true;
-    }
-
-    // all position splits
-    else if (settings["manySplits"] && version != "Undetected" && vars.ShouldSplitAtThisPos(current.chapter, current.act, vars.gameTimerIsPaused.Changed, current.x, current.y, current.z) && vars.splitsLockTimer.ElapsedMilliseconds > 10000){
-        vars.splitsLockTimer.Restart();
-        return true;
-    }
-
-    return false;
+            settings["manySplits"] && vars.currentRift != "none"
+                &&
+                (
+                (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 || vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0) && (settings[vars.currentRift + "_tp"]) // custom time piece (rifts)
+                ||
+                current.checkpoint > old.checkpoint && settings[vars.currentRift + "_cp"] // new purple rift checkpoint
+                ||
+                vars.justEnteredRift && settings[vars.currentRift + "_entry"] && !settings["settings_ILMode"] // rift entry
+                );
 }
 
 reset {

--- a/AHatInTime.asl
+++ b/AHatInTime.asl
@@ -1,3 +1,5 @@
+// TODO: cp, cp_pause, cp_pause_pos, decide what to do with pos splits (alpine and slap), test act entries, add all rift splits
+
 state("HatinTimeGame", "DLC 2.1") {
     int chapter : 0x011E1570, 0x68, 0x108;
     int act : 0x011E1570, 0x68, 0x10C;
@@ -37,6 +39,14 @@ startup {
         "45 4E 44 20" // END
     );
 
+    settings.Add("settings", true, "Settings");
+    settings.CurrentDefaultParent = "settings";
+    settings.Add("IL_mode", false, "IL Mode - Follow the act timer instead of the game timer");
+    settings.SetToolTip("IL_mode", "This will also start the timer when the act timer is at 0, and reset when using \"restartil\" or exiting a level.");
+    settings.Add("settings_new_file_start", true, "Only start the timer when opening an empty file");
+    settings.Add("game_time_message", true, "Ask if Game Time should be used when the game opens");
+
+    settings.CurrentDefaultParent = null;
     settings.Add("splits", true, "Splits");
     settings.CurrentDefaultParent = "splits";
     settings.Add("splits_tp", true, "Time Pieces");
@@ -68,29 +78,73 @@ startup {
         for (int i = 1; i <= 7; i++){
             if ((j <= 4) && string.Compare(actNames[j-1, i-1], "") != 0){
                 settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i, true, actNames[j-1, i-1], "manySplits_" + (j == 4 ? 6 : j));
-                settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i + "_tp", true, "Time Piece", "manySplits_" + (j == 4 ? 6 : j) + "_" + i);
-                settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i + "_tpDelayed", false, "Load Screen After Getting Time Piece", "manySplits_" + (j == 4 ? 6 : j) + "_" + i);
+                settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i + "_entry", false, "Telescope Entry", "manySplits_" + (j == 4 ? 6 : j) + "_" + i);
             }
             else {
-                continue;
+                i = 8;
             }
         }
         if (j == 4 || j == 5 || j == 7){
-            settings.Add("manySplits_" + j + "_tp", true, "Time Pieces", "manySplits_" + j);
+            settings.Add("manySplits_" + j + "_entry", false, "Telescope Entry", "manySplits_" + j);
         }
     }
 
-    settings.CurrentDefaultParent = null;
-    settings.Add("settings", true, "Settings");
-    settings.CurrentDefaultParent = "settings";
-    settings.Add("IL_mode", false, "IL Mode - Follow the act timer instead of the game timer");
-    settings.SetToolTip("IL_mode", "This will also start the timer when the act timer is at 0, and reset when using \"restartil\" or exiting a level.");
-    settings.Add("settings_new_file_start", true, "Only start the timer when opening an empty file");
-    settings.Add("game_time_message", true, "Ask if Game Time should be used when the game opens");
+    settings.Add("manySplits_1_1_cp1", false, "Umbrella Fight", "manySplits_1_1");
+    settings.Add("manySplits_1_2_cp1", false, "Battle Start", "manySplits_1_2");
+    settings.Add("manySplits_1_3_cp1", false, "Scare", "manySplits_1_3");
+    settings.Add("1_4_cp0_pause_pos", false, "Enter HQ", "manySplits_1_4");
+    settings.Add("manySplits_1_4_cp1", false, "Vent", "manySplits_1_4");
+    settings.Add("manySplits_1_4_cp2", false, "Boss", "manySplits_1_4");
+    settings.Add("manySplits_1_6_cp59_pause", false, "Death", "manySplits_1_6");
+    settings.SetToolTip("manySplits_1_6_cp59_pause", "Make sure you are doing on of the ice hat routes for this to work.");
+
+    settings.Add("manySplits_2_1_cp5", false, "Warp Exploit", "manySplits_2_1");
+    settings.Add("manySplits_2_4_cp1", false, "Intro", "manySplits_2_4");
+    settings.Add("manySplits_2_4_cp4", false, "Exit to Roof", "manySplits_2_4");
+    settings.Add("manySplits_2_5_cp1", false, "Intro", "manySplits_2_5");
+    settings.Add("manySplits_2_5_cp2", false, "Waiting Time #1", "manySplits_2_5");
+    settings.Add("manySplits_2_5_cp3", false, "Waiting Time #2", "manySplits_2_5");
+    settings.SetToolTip("manySplits_2_6", "This is for the fake and real finale time pieces / entries.");
+    settings.Add("manySplits_2_6_cp0_pause_pos", false, "Elevator to Boss", "manySplits_2_6");
+
+    settings.Add("manySplits_3_2_cp0_pause_pos", false, "Inside Well", "manySplits_3_2");
+    settings.Add("manySplits_3_3_cp1", false, "Fight Start", "manySplits_3_3");
+    settings.Add("manySplits_3_4_cp0_pause_pos", false, "Inside Manor", "manySplits_3_4");
+    settings.Add("manySplits_3_6_cp1", false, "Fight Start", "manySplits_3_6");
+
+    settings.Add("manySplits_4_99_cp0_pause_pos", false, "Intro End", "manySplits_4");
+    settings.SetToolTip("manySplits_4_99_cp0_pause_pos", "Triggered when going back to hub right after the screen fades to white in the zipline.");
+
+    settings.Add("manySplits_5_1_cp10", false, "Hyper Zone", "manySplits_5");
+
+    settings.Add("manySplits_6_1_cp3", false, "Check-in", "manySplits_6_1");
+    settings.Add("manySplits_6_2_cp1", false, "Job Start", "manySplits_6_2");
+    settings.Add("manySplits_6_3_cp1", false, "Sink the Boat", "manySplits_6_3");
+    settings.Add("manySplits_6_3_cp2", false, "First Group Saved", "manySplits_6_3");
+    settings.Add("manySplits_6_3_cp3", false, "Second Group Saved", "manySplits_6_3");
+
+    // insert rift splits here
+
+    for (int j = 1; j <= 7; j++){
+        for (int i = 1; i <= 7; i++){
+            if ((j <= 4) && string.Compare(actNames[j-1, i-1], "") != 0){
+                settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i + "_tp", true, "Time Piece", "manySplits_" + (j == 4 ? 6 : j) + "_" + i);
+                settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i + "_tpDelayed", false, "Delayed Time Piece", "manySplits_" + (j == 4 ? 6 : j) + "_" + i);
+                settings.SetToolTip("manySplits_" + (j == 4 ? 6 : j) + "_" + i + "_tpDelayed", "This triggers on the loading screen after getting the time piece.");
+            }
+            else {
+                i = 8;
+            }
+        }
+        if (j == 4 || j == 5 || j == 7){
+            settings.Add("manySplits_" + j + "_tp", true, "Time Piece" + (j == 5 ? "" : "s"), "manySplits_" + j);
+        }
+    }
 
     vars.lastChapter = 0; // used by seal the deal split
     vars.splitInLoadScreen = false;
-}
+    vars.splitsLock = false; // locks splits, prevents multiple splits on loading screens
+    }
 
 init {
 
@@ -177,6 +231,7 @@ update {
     }
     if (vars.gameTimerIsPaused.Current == 0 && vars.gameTimerIsPaused.Old == 1){
         vars.splitInLoadScreen = false;
+        vars.splitsLock = false;
     }
 }
 
@@ -187,18 +242,40 @@ start {
 }
 
 split {
-    if (vars.timerState.Current == 0){
-        return false;
-    }
-
-    if (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 && (settings["splits_tp_new"] || (version != "Undetected" && settings["manySplits_" + current.chapter + "_" + current.act + "_tp"])) ||
-        vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && (settings["splits_tp_any"] || (version != "Undetected" && settings["manySplits_" + current.chapter + "_" + current.act + "_tp"]))||
-        version != "Undetected" && vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && current.chapter == 3 && vars.lastChapter == 5 && settings["splits_tp_std"] ||
-        version != "Undetected" && current.chapter == 97 && old.chapter != 97 && settings["splits_dwbth"] ||
-        vars.splitInLoadScreen && vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0){
+    if (vars.timerState.Current != 0 && !vars.splitsLock
+        &&
+        (
+        settings["splits"] 
+            &&
+            (
+            vars.timePieceCount.Current == vars.timePieceCount.Old + 1 && settings["splits_tp_new"]  // new time piece
+            ||
+            vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && settings["splits_tp_any"]  // any time piece
+            ||
+            vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && version != "Undetected" && current.chapter == 3 && vars.lastChapter == 5 && settings["splits_tp_std"]  // seal the deal
+            ||
+            version != "Undetected" && current.chapter == 97 && old.chapter != 97 && settings["splits_dwbth"]  // death wish back to hub
+            )
+        ||
+        settings["manySplits"] && version != "Undetected" 
+            &&
+            (
+            (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 || vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0) && (settings["manySplits_" + current.chapter + "_" + current.act + "_tp"] || settings["manySplits_" + current.chapter + "_"])  // custom time pieces
+            ||
+            vars.splitInLoadScreen && vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0  // delayed custom time pieces
+            )
+        )
+        )
+        {
             return true;
         }
 
+    // pause screen splits
+    else if (vars.realActTime.Current == 0f && settings["manySplits_" + current.chapter + "_" + current.act + "_entry"]){
+        vars.splitsLock = true;
+        return true;
+    }
+    
     return false;
 }
 

--- a/AHatInTime.asl
+++ b/AHatInTime.asl
@@ -1,17 +1,21 @@
 state("HatinTimeGame", "DLC 2.1") {
     int chapter : 0x011E1570, 0x68, 0x108;
+    int act : 0x011E1570, 0x68, 0x10C;
 }
 
 state("HatinTimeGame", "110% Patch") {
     int chapter : 0x0121F280, 0x68, 0x108;
+    int act : 0x0121F280, 0x68, 0x10C;
 }
 
 state("HatinTimeGame", "DLC 1.5") {
-	int chapter: 0x011E7550, 0x68, 0x108;
+    int chapter: 0x011E7550, 0x68, 0x108;
+    int act : 0x011E7550, 0x68, 0x10C;
 }
 
 state("HatinTimeGame", "Modding") {
-	int chapter : 0x011475A8, 0x64, 0xF8;
+    int chapter : 0x011475A8, 0x64, 0xF8;
+    int act : 0x011475A8, 0x64, 0xFC;
 }
 
 startup {
@@ -45,6 +49,38 @@ startup {
     settings.SetToolTip("splits_dwbth", "Only works on detected patches.");
     settings.CurrentDefaultParent = null;
 
+    settings.Add("manySplits", false, "Detailed Splits");
+    settings.SetToolTip("manySplits", "If you want more customizable options, use these splits instead.\nThey only work on detected patches.");
+
+    string[] chapterNames = new string[7] {"Mafia Town", "Battle of the Birds", "Subcon Forest", "Alpine Skyline", "Time's End - The Finale", "The Artic Cruise", "Nyakuza Metro"};
+
+    for (int i = 1; i <= 7; i++){
+        settings.Add("manySplits_" + i, true, chapterNames[i-1], "manySplits");
+    }
+
+    string[,] actNames = new string[4, 7]{
+        {"Welcome to Mafia Town", "Barrel Battle", "She Came From Outer Space", "Down With The Mafia!", "Cheating The Race", "Heating Up Mafia Town", "The Golden Vault"},
+        {"Dead Bird Studio", "Murder on the Owl Express", "Picture Perfect", "Train Rush", "The Big Parade", "Award Ceremony", ""},
+        {"Contractual Obligations", "The Subcon Well", "Toilet of Doom", "Queen Vanessa's Manor", "Mail Delivery Service", "Your Contract Has Expired", ""},
+        {"Bon Voyage!", "Ship Shape", "Rock The Boat", "", "", "", ""}};
+
+    for (int j = 1; j <= 7; j++){
+        for (int i = 1; i <= 7; i++){
+            if ((j <= 4) && string.Compare(actNames[j-1, i-1], "") != 0){
+                settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i, true, actNames[j-1, i-1], "manySplits_" + (j == 4 ? 6 : j));
+                settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i + "_tp", true, "Time Piece", "manySplits_" + (j == 4 ? 6 : j) + "_" + i);
+                settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i + "_tpDelayed", false, "Load Screen After Getting Time Piece", "manySplits_" + (j == 4 ? 6 : j) + "_" + i);
+            }
+            else {
+                continue;
+            }
+        }
+        if (j == 4 || j == 5 || j == 7){
+            settings.Add("manySplits_" + j + "_tp", true, "Time Pieces", "manySplits_" + j);
+        }
+    }
+
+    settings.CurrentDefaultParent = null;
     settings.Add("settings", true, "Settings");
     settings.CurrentDefaultParent = "settings";
     settings.Add("IL_mode", false, "IL Mode - Follow the act timer instead of the game timer");
@@ -53,24 +89,25 @@ startup {
     settings.Add("game_time_message", true, "Ask if Game Time should be used when the game opens");
 
     vars.lastChapter = 0; // used by seal the deal split
+    vars.splitInLoadScreen = false;
 }
 
 init {
 
     if (timer.CurrentTimingMethod == TimingMethod.RealTime && settings["game_time_message"]){
-		var message = MessageBox.Show(
-			"Would you like to change the current timing method to\nGame Time instead of Real Time?", 
-			"LiveSplit | A Hat in Time Auto Splitter", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-			
-	    if (message == DialogResult.Yes)
-			timer.CurrentTimingMethod = TimingMethod.GameTime;
-	}
+        var message = MessageBox.Show(
+            "Would you like to change the current timing method to\nGame Time instead of Real Time?", 
+            "LiveSplit | A Hat in Time Auto Splitter", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
-	switch (modules.First().ModuleMemorySize) {
+        if (message == DialogResult.Yes)
+            timer.CurrentTimingMethod = TimingMethod.GameTime;
+    }
+
+    switch (modules.First().ModuleMemorySize) {
         case 0x13AF000: version = "DLC 2.1"; break;
         case 0x13F0000: version = "110% Patch"; break;
-		case 0x13B3000: version = "DLC 1.5"; break;
-		case 0x1260000: version = "Modding"; break;
+        case 0x13B3000: version = "DLC 1.5"; break;
+        case 0x1260000: version = "Modding"; break;
         default: version = "Undetected"; break;
     }
 
@@ -109,8 +146,8 @@ init {
     vars.justGotTimePiece = new MemoryWatcher<int>(ptr + 0x20);
     vars.gameTime = new MemoryWatcher<double>(ptr + 0x24);
     vars.actTime = new MemoryWatcher<double>(ptr + 0x2C);
-	vars.realGameTime = new MemoryWatcher<double>(ptr + 0x34);
-	vars.realActTime = new MemoryWatcher<double>(ptr + 0x3C);
+    vars.realGameTime = new MemoryWatcher<double>(ptr + 0x34);
+    vars.realActTime = new MemoryWatcher<double>(ptr + 0x3C);
     vars.timePieceCount = new MemoryWatcher<int>(ptr + 0x44);
 
     vars.watchers = new MemoryWatcherList() {
@@ -123,8 +160,8 @@ init {
         vars.justGotTimePiece,
         vars.gameTime,
         vars.actTime,
-		vars.realGameTime,
-		vars.realActTime,
+        vars.realGameTime,
+        vars.realActTime,
         vars.timePieceCount
     };
 }
@@ -133,6 +170,12 @@ update {
     vars.watchers.UpdateAll(game);
     if (version != "Undetected" && current.chapter != old.chapter){
         vars.lastChapter = old.chapter;
+    }
+    if (version != "Undetected" && (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 || vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0) && settings["manySplits_" + current.chapter + "_" + current.act + "_tpDelayed"]){
+        vars.splitInLoadScreen = true;
+    }
+    if (vars.gameTimerIsPaused.Current == 0 && vars.gameTimerIsPaused.Old == 1){
+        vars.splitInLoadScreen = false;
     }
 }
 
@@ -143,10 +186,11 @@ start {
 }
 
 split {
-    if (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 && settings["splits_tp_new"] ||
-        vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && settings["splits_tp_any"] ||
+    if (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 && (settings["splits_tp_new"] || (version != "Undetected" && settings["manySplits_" + current.chapter + "_" + current.act + "_tp"])) ||
+        vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && (settings["splits_tp_any"] || (version != "Undetected" && settings["manySplits_" + current.chapter + "_" + current.act + "_tp"]))||
         version != "Undetected" && vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && current.chapter == 3 && vars.lastChapter == 5 && settings["splits_tp_std"] ||
-        current.chapter == 97 && old.chapter != 97 && settings["splits_dwbth"]){
+        current.chapter == 97 && old.chapter != 97 && settings["splits_dwbth"] ||
+        vars.splitInLoadScreen && vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0){
             return true;
         }
 
@@ -162,5 +206,5 @@ isLoading {
 }
 
 gameTime {
-	return settings["IL_mode"] ? TimeSpan.FromSeconds(vars.realActTime.Current) : TimeSpan.FromSeconds(vars.realGameTime.Current);
+    return settings["IL_mode"] ? TimeSpan.FromSeconds(vars.realActTime.Current) : TimeSpan.FromSeconds(vars.realGameTime.Current);
 }

--- a/AHatInTime.asl
+++ b/AHatInTime.asl
@@ -425,7 +425,7 @@ update {
             vars.justEnteredRift = false;
         }
         // rift entry detection
-        if (vars.gameTimerIsPaused.Changed && vars.currentRift == "none"){
+        if (vars.gameTimerIsPaused.Changed && vars.currentRift == "none" && settings["manySplits"]){
             vars.currentRift = vars.CurrentRiftCheck(current.chapter, current.x, current.y, current.z);
             if (vars.currentRift != "none"){
                 vars.justEnteredRift = true;

--- a/AHatInTime.asl
+++ b/AHatInTime.asl
@@ -1,7 +1,3 @@
-// TODO: add all rift splits
-// done: custom tp, delayed tp, act entry, cp, cp_pause, cp_pause_pos, all pos splits,
-// bonus: initial load is much faster now
-
 state("HatinTimeGame", "DLC 2.1") {
     float x : 0x011BC360, 0x6DC, 0x00, 0x68, 0x51C, 0x80;
     float y : 0x011BC360, 0x6DC, 0x00, 0x68, 0x51C, 0x84;
@@ -68,7 +64,7 @@ startup {
     settings.Add("settings_newFileStart", true, "Only start the timer when opening an empty file");
     settings.Add("settings_gameTimeMsg", true, "Ask if Game Time should be used when the game opens");
     settings.Add("settings_noResetIntro", false, "Avoid resetting when going back to main menu after starting a new file");
-    settings.SetToolTip("settings_noResetIntro", "Timer won't reset at hat kid's room when she has 0 timpepieces.\nSupported patches only.");
+    settings.SetToolTip("settings_noResetIntro", "Timer won't reset at hat kid's room when she has 0 timpepieces.\nOnly works on detected patches.");
 
     settings.CurrentDefaultParent = null;
     settings.Add("splits", true, "Splits");
@@ -80,7 +76,7 @@ startup {
     settings.Add("splits_tp_std", true, "Seal The Deal", "splits_tp");
     settings.SetToolTip("splits_tp_std", "End of Death Wish Any%.\nOnly works on detected patches.");
     settings.Add("splits_actEntry", false, "Act Entries");
-    settings.SetToolTip("splits_actEntry", "Also for time rifts in the spaceship.");
+    settings.SetToolTip("splits_actEntry", "When using undetected patches it will also trigger for time rifts in the spaceship.");
     settings.Add("splits_dwbth", false, "Death Wish Level Back to Hub");
     settings.SetToolTip("splits_dwbth", "Only works on detected patches.");
     settings.CurrentDefaultParent = null;
@@ -102,7 +98,7 @@ startup {
 
     for (int j = 1; j <= 7; j++){
         for (int i = 1; i <= 7; i++){
-            if (j <= 4 && string.Compare(actNames[j-1, i-1], "") != 0){
+            if (j <= 4 && actNames[j-1, i-1] != ""){
                 settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i, true, actNames[j-1, i-1], "manySplits_" + (j == 4 ? 6 : j));
                 settings.Add("manySplits_" + (j == 4 ? 6 : j) + "_" + i + "_entry", false, "Entry", "manySplits_" + (j == 4 ? 6 : j) + "_" + i);
             }
@@ -154,6 +150,12 @@ startup {
 
     settings.CurrentDefaultParent = null;
 
+    settings.Add("manySplits_5_1_cp1", false, "Enter Castle", "manySplits_5");
+    settings.SetToolTip("manySplits_5_1_cp1", "Only recommended for ILs");
+    settings.Add("manySplits_5_1_cp2", false, "Big Doors 1", "manySplits_5");
+    settings.SetToolTip("manySplits_5_1_cp2", "Only recommended for ILs");
+    settings.Add("manySplits_5_1_cp3", false, "Big Doors 2", "manySplits_5");
+    settings.SetToolTip("manySplits_5_1_cp3", "Only recommended for ILs");
     settings.Add("manySplits_5_slap", false, "Slap", "manySplits_5");
     settings.Add("manySplits_5_1_cp10", false, "Hyper Zone", "manySplits_5");
 
@@ -162,8 +164,6 @@ startup {
     settings.Add("manySplits_6_3_cp1", false, "Sink the Boat", "manySplits_6_3");
     settings.Add("manySplits_6_3_cp2", false, "First Group Saved", "manySplits_6_3");
     settings.Add("manySplits_6_3_cp3", false, "Second Group Saved", "manySplits_6_3");
-
-    // insert rift splits here
 
     for (int j = 1; j <= 7; j++){
         for (int i = 1; i <= 7; i++){
@@ -181,35 +181,39 @@ startup {
         }
     }
 
+    settings.Add("manySplits_riftBlue", true, "Time Rift - Blue", "manySplits");
+    settings.Add("manySplits_riftPurple", true, "Time Rift - Purple", "manySplits");
+
+    string[,] riftNames = new string[2, 11]{
+    {"The Gallery", "The Lab", "Sewers", "Bazaar", "The Owl Express", "The Moon", "Village", "Pipe", "Twilight Bell", "Curly Tail Trail", "Balcony"},
+    {"Mafia of Cooks", "Dead Bird Studio", "Sleepy Subcon", "Alpine Skyline", "Deep Sea", "Rumbi Factory", "Tour", "", "", "", ""}};
+
+    string[,] riftIds = new string[2, 11]{
+    {"gallery", "lab", "sewers", "bazaar", "owlExpress", "moon", "village", "pipe", "twilight", "curly", "balcony"},
+    {"moc", "dbs", "sleepy", "alpine", "deepSea", "rumbi", "tour", "", "", "", ""}};
+
+    for (int i = 0; i <= 1; i++){
+        for (int j = 0; j <= 10; j++){
+            if (i == 0){ 
+                settings.Add("manySplits_riftBlue_" + riftIds[0,j], true, riftNames[0, j], "manySplits_riftBlue");
+                settings.Add("manySplits_riftBlue_" + riftIds[0,j] + "_entry", false, "Entry", "manySplits_riftBlue_" + riftIds[0,j]);
+                settings.Add("manySplits_riftBlue_" + riftIds[0,j] + "_tp", true, "Time Piece", "manySplits_riftBlue_" + riftIds[0,j]);
+            }
+            else if (riftNames[1, j] != ""){
+                settings.Add("manySplits_riftPurple_" + riftIds[1,j], true, riftNames[1, j], "manySplits_riftPurple");
+                settings.Add("manySplits_riftPurple_" + riftIds[1,j] + "_entry", false, "Entry", "manySplits_riftPurple_" + riftIds[1,j]);
+                settings.Add("manySplits_riftPurple_" + riftIds[1,j] + "_cp", false, "Room Completed", "manySplits_riftPurple_" + riftIds[1,j]);
+                settings.Add("manySplits_riftPurple_" + riftIds[1,j] + "_tp", true, "Time Piece", "manySplits_riftPurple_" + riftIds[1,j]);
+            }
+        }
+    }
+
     vars.lastChapter = 0; // used by seal the deal split
     vars.splitInLoadScreen = false;
     vars.splitsLockTimer = new Stopwatch();
     vars.splitsLockTimer.Start();
-
-    // updates a text component in the layout, also creates it if it doesn't exist
-	Action <string, string> UpdateTextComponent = (string name, string updatedText) => {
-		bool foundComponent = false;
-		foreach (dynamic component in timer.Layout.Components){
-			if (component.GetType().Name != "TextComponent" || component.Settings.Text1 != name) continue;
-			component.Settings.Text2 = updatedText;
-			foundComponent = true;
-			break;
-		}
-		if (!foundComponent) vars.CreateTextComponent(name, updatedText);
-	};
-	vars.UpdateTextComponent = UpdateTextComponent;
-	
-	// creates a text component, used when UpdateTextComponent doens't find the text component requested
-	Action <string, string> CreateTextComponent = (string textLeft, string textRight) => {
-		var textComponentAssembly = Assembly.LoadFrom("Components\\LiveSplit.Text.dll");
-		dynamic textComponent = Activator.CreateInstance(textComponentAssembly.GetType("LiveSplit.UI.Components.TextComponent"), timer);
-		timer.Layout.LayoutComponents.Add(new LiveSplit.UI.Components.LayoutComponent("LiveSplit.Text.dll", textComponent as LiveSplit.UI.Components.IComponent));
-		textComponent.Settings.Text1 = textLeft;
-		textComponent.Settings.Text2 = textRight;
-	};
-	vars.CreateTextComponent = CreateTextComponent;
-
-    }
+    vars.currentRift = "none"; // indicates the current time rift, none -> not in a rift
+}
 
 init {
 
@@ -289,11 +293,11 @@ init {
     Func <int, int, bool, float, float, float, bool> ShouldSplitAtThisPos = (int chapter, int act, bool timerChangedState, float x, float y, float z) => {
     return(chapter == 4 && (act != 4  && settings["4_birdhouse"] && x > -24000f&& x < -23000f&& y > 29000f  && y < 30500f && z > 4000f  && z < 6000f  ||   // birdhouse arrival
                             act != 3  && settings["4_lava_cake"] && x > 3000f  && x < 30400f && y > -28500f && y < -27353f&& z > 3200f  && z < 4000f  ||   // lava cake arrival
-                            act != 13 && settings["4_windmill"] && x > 71600f && x < 72300f && y > 21500f  && y < 22700f && z > 1500f  && z < 2100f   ||   // windmill arrival
-                            act != 15 && settings["4_twilight"] && x > 4600f  && x < 8700f  && y > 69000f  && y < 70000f && z > 4000f  && z < 5400f   ||   // twilight bell arrival
+                            act != 13 && settings["4_windmill"]  && x > 71600f && x < 72300f && y > 21500f  && y < 22700f && z > 1500f  && z < 2100f  ||   // windmill arrival
+                            act != 15 && settings["4_twilight"]  && x > 4600f  && x < 8700f  && y > 69000f  && y < 70000f && z > 4000f  && z < 5400f  ||   // twilight bell arrival
                             settings["4_illness_bh"]   && x > -20000f && x < -10000f && y > 45000f  && y < 52500f && z < -9680f                       ||   // illness birdhouse warp
                             settings["4_illness_wind"] && x > 38000f  && x < 47000f  && y > 28000f  && y < 34000f && z < -9680f)                      ||   // illness windmill warp
-            chapter == 5 && settings["manySplits_5_slap"] && x > -38300f && x <-38190f && y > -85000f && y <-84000f && z >-59900f && z <-59000f        ||   // slap (5-1)
+            chapter == 5 && settings["manySplits_5_slap"] && x > -38300f && x <-38190f && y > -85000f && y <-84000f && z >-59900f && z <-59000f       ||   // slap (5-1)
             
             timerChangedState  &&  (chapter == 1 && settings["manySplits_1_4_cp0_pause_pos"] && x > 3500f  && x < 4500f  && y > -3500f  && y < -3000f && z > 8000f  && z < 9000f    ||   // mafia boss enter HQ (1-4)
                                     chapter == 2 && settings["manySplits_2_6_cp0_pause_pos"] && x > 5500f  && x < 9500f  && y > 8200f   && y < 12000f && z < 5000f                  ||   // basement boss entry (2-6)
@@ -302,6 +306,56 @@ init {
                                     chapter == 4 && settings["manySplits_4_99_cp0_pause_pos"]&& x > 37000f && x < 41000f && y > 47000f  && y < 51000f && z > -14000f&& z < -5000f ));    // alpine intro (4-99)
     };
     vars.ShouldSplitAtThisPos = ShouldSplitAtThisPos;
+
+    // returns the current rift based on hat kid's position
+    Func <int, float, float, float, string> CurrentRiftCheck = (int chapter, float x, float y, float z) => {
+        // purple rifts are detected with the rift orb OR hat kid's position at the start of them
+        if      (chapter == 1 && x > 4070f  && x < 4250f  && y > -5550f  && y < -5350f  && z > -900f  && z < -700f ||
+                                 x > 13200f && x < 13250f && y > -120f   && y < -80f    && z > -250f )               return "manySplits_riftPurple_moc";
+        else if (chapter == 2 && x > 8350f  && x < 8500f  && y > -2250f  && y < -2100f  && z > 2700f  && z < 2870f ||
+                                 x > 7750f  && x < 7800f  && y > -10500f && y < -10400f && z > 1000f)                return "manySplits_riftPurple_dbs";
+        else if (chapter == 3 && x > 13100f && x < 13300f && y > 25150f  && y < 25350f  && z > 2300f && z < 2500f  ||
+                                 x > 6100f  && x < 6150f  && y > 32400f  && y < 32500f  && z > 550f)                 return "manySplits_riftPurple_sleepy"; 
+        else if (chapter == 4 && x > 16700f && x < 16850f && y > 28750f  && y < 28900f  && z >-5100f  && z <-4800f ||
+                                 x >-11700f && x <-11600f && y > -11700f && y <-11600f  && z >-4000f)                return "manySplits_riftPurple_alpine";
+        else if (chapter == 6 && x > 1860f  && x < 3000f  && y > 6400f   && y < 6550f   && z > 4000f && z < 4200f  ||
+                                 x > -15700f&& x < -15600f&& y > 870f    && y < 910f    && z > 3200f)                return "manySplits_riftPurple_deepSea";
+        else if (chapter == 7 && x > 750f   && x < 900f   && y > 1200f   && y < 1350f   && z > 1250f && z < 1450f  ||
+                                 x > -400f  && x < -300f  && y > -8400f  && y < -8300f  && z > 1000f)                return "manySplits_riftPurple_rumbi";
+        else if (                x > -4220f && x < -4120f && y > -800f   && y < -710f   && z > 1300f && z < 1500f  ||
+                                 x > 13100f && x < 13200f && y > -250f   && y < -200f   && z > 2650f)                return "manySplits_riftPurple_tour";
+        
+        // blue rifts are detected with hat kid's position at the start of them
+        else if (chapter == 1 && x > -200f  && x < -150f  && y > -410f   && y < -360f   && z > 60f   && z < 120f)  return "manySplits_riftBlue_sewers";
+        else if (chapter == 1 && x > -200f  && x < -150f  && y > -150f   && y < -120f   && z > 60f   && z < 120f)  return "manySplits_riftBlue_bazaar";
+        else if (chapter == 2 && x > -2710f && x < -2500f && y > 1020f   && y < 1230f   && z > 10f   && z < 100f)  return "manySplits_riftBlue_owlExpress";
+        else if (chapter == 2 && x > 2600f  && x < 2850   && y > 850f    && y < 1100f   && z > 0f    && z < 100f)  return "manySplits_riftBlue_moon";
+        else if (chapter == 3 && x > -2800f && x < -2400f && y > -1800f  && y < -1450f  && z > 60f   && z < 120f)  return "manySplits_riftBlue_village";
+        else if (chapter == 3 && x > 1780f  && x < 2000f  && y > -11384f && y < -9350f  && z > 60f   && z < 120f)  return "manySplits_riftBlue_pipe";
+        else if (chapter == 4 && x > 7600f  && x < 7900f  && y > 1100f   && y < 1400f   && z > -500f && z < -100f) return "manySplits_riftBlue_twilight";
+        else if (chapter == 4 && x > 5700f  && x < 6000f  && y > 3100f   && y < 3400f   && z > -500f && z < -100f) return "manySplits_riftBlue_curly";
+        else if (chapter == 6 && x > 3700f  && x < 3950f  && y > 4300f   && y < 4550f   && z > 1200f && z < 1400f) return "manySplits_riftBlue_balcony";
+        else if (                x > -1180f && x < -920f  && y > 4050f   && y < 4350f   && z > 200f  && z < 300f)  return "manySplits_riftBlue_lab";
+        else if (                x >  7250f && x < 7550f  && y > 100f    && y < 400f    && z > -500f && z < -400f) return "manySplits_riftBlue_gallery";
+        else return "none";
+    };
+    vars.CurrentRiftCheck = CurrentRiftCheck;
+
+    // checks if hat kid was moved to the hub
+    Func <int, float, float, float, bool> BackToHubCheck = (int chapter, float x, float y, float z) => {
+    return (                 x > -680f   && x < -670f   && y > 1535f  && y < 1545f  && z > 235f  && z < 250f   ||
+            chapter == 1  && x > 295f    && x < 325f    && y > 95f    && y < 125f                              ||
+            chapter == 2  && x > 2445f   && x < 2455f   && y > 210f   && y < 220f   && z > 80f   && z < 130f   ||
+            chapter == 2  && x > 2400f   && x < 2450f   && y > -60f   && y < -40f   && z > 40f   && z < 100f   ||  // older patches
+            chapter == 3  && x > -2020f  && x < -2010f  && y > -1910f && y < -1900f && z > 30f   && z < 100f   ||
+            chapter == 4  && x > -590f   && x < -580f   && y > -3965f && y < -3955f && z > -315f && z < -250f  ||
+            chapter == 5  && x > -1265f  && x < -1255f  && y > -25f   && y < -15f   && z > 290f  && z < 340f   ||
+            chapter == 6  && x > 20365f  && x < 20375f  && y > -23840f&& y < -23830f&& z > 1280f && z < 1330f  ||
+            chapter == 7  && x > 26260f  && x < 26270f  && y > -23015f&& y < -23005 && z > 1290f && z < 1400f  ||
+            chapter == 97 && x > -2310f  && x < -2300f  && y > -2085f && y < -2075f && z > 35f   && z < 100f   ||  // death wish
+            chapter == 99 && x > 1600f   && x < 1610f   && y > 1625f  && y < 1635f  && z > 405f  && z < 455f   );  // mod levels
+    };
+    vars.BackToHubCheck = BackToHubCheck;
 }
 
 update {
@@ -314,11 +368,11 @@ update {
     }
     if (vars.gameTimerIsPaused.Current == 0 && vars.gameTimerIsPaused.Old == 1){
         vars.splitInLoadScreen = false;
+        vars.currentRift = (vars.BackToHubCheck(current.chapter, current.x, current.y, current.z) ? "none" : vars.currentRift);
     }
-
-    vars.UpdateTextComponent("X", current.x.ToString());
-    vars.UpdateTextComponent("Y", current.y.ToString());
-    vars.UpdateTextComponent("Z", current.z.ToString());
+    if (vars.timerState.Current == 0){
+        vars.currentRift = "none";
+    }
 }
 
 start {
@@ -328,10 +382,17 @@ start {
 }
 
 split {
-    if (vars.timerState.Current != 0
-        &&
-        (
-        settings["splits"] 
+    if (vars.timerState.Current == 0){
+        return false;
+    }
+
+    // rift entry detection + split
+    if (vars.gameTimerIsPaused.Changed && version != "Undetected" && vars.currentRift == "none" && settings["manySplits"]){
+        vars.currentRift = vars.CurrentRiftCheck(current.chapter, current.x, current.y, current.z);
+        return settings[vars.currentRift + "_entry"];
+    }
+
+    if (settings["splits"] 
             &&
             (
             vars.timePieceCount.Current == vars.timePieceCount.Old + 1 && settings["splits_tp_new"]  // new time piece
@@ -340,44 +401,50 @@ split {
             ||
             vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && version != "Undetected" && current.chapter == 3 && vars.lastChapter == 5 && settings["splits_tp_std"]  // seal the deal
             ||
-            vars.realActTime.Old == 0f && vars.actTimerIsPaused.Current == 0 && vars.actTimerIsPaused.Old == 1 // act entry
+            vars.realActTime.Old == 0f && vars.actTimerIsPaused.Current == 0 && vars.actTimerIsPaused.Old == 1 && settings["splits_actEntry"] && vars.currentRift == "none" && !settings["settings_ILMode"] // act entry
             ||
             version != "Undetected" && current.chapter == 97 && old.chapter != 97 && settings["splits_dwbth"]  // death wish back to hub
             )
         ||
-        settings["manySplits"] && version != "Undetected" 
+        settings["manySplits"] && version != "Undetected" && vars.currentRift == "none"
             &&
             (
             (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 || vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0) && (settings["manySplits_" + current.chapter + "_" + current.act + "_tp"] || settings["manySplits_" + current.chapter + "_"])  // custom time pieces
             ||
-            current.checkpoint != old.checkpoint && settings["manySplits_" + current.chapter + "_" + current.act + "_cp" + current.checkpoint] // new checkpoint
+            current.checkpoint != old.checkpoint && settings["manySplits_" + current.chapter + "_" + current.act + "_cp" + current.checkpoint] // new act checkpoint
             ||
             vars.splitInLoadScreen && vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0  // delayed custom time pieces
             ||
-            vars.realActTime.Old == 0f && vars.actTimerIsPaused.Current == 0 && vars.actTimerIsPaused.Old == 1 && (settings["manySplits_" + current.chapter + "_" + current.act + "_entry"] || settings["manySplits_" + current.chapter + "_entry"]) // custom act entry
+            vars.realActTime.Old == 0f && vars.actTimerIsPaused.Current == 0 && vars.actTimerIsPaused.Old == 1 && !settings["settings_ILMode"] && (settings["manySplits_" + current.chapter + "_" + current.act + "_entry"] || settings["manySplits_" + current.chapter + "_entry"]) // custom act entry
             ||
             vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0 && settings["manySplits_" + current.chapter + "_" + current.act + "_cp" + current.checkpoint + "_pause"] // paused with certain checkpoint
             )
+        ||
+        settings["manySplits"] && vars.currentRift != "none"
+            &&
+            (
+            (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 || vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0) && (settings[vars.currentRift + "tp"]) // custom time piece (rifts)
+            ||
+            current.checkpoint > old.checkpoint && settings[vars.currentRift + "_cp"] // new purple rift checkpoint
+            )
         )
-        )
-        {
-            return true;
-        }
-        // all position splits
-        else if (version != "Undetected" && vars.ShouldSplitAtThisPos(current.chapter, current.act, vars.gameTimerIsPaused.Changed, current.x, current.y, current.z) && vars.splitsLockTimer.ElapsedMilliseconds > 10000){
-            vars.splitsLockTimer.Restart();
-            return true;
-        }
+    {
+        return true;
+    }
+
+    // all position splits
+    else if (settings["manySplits"] && version != "Undetected" && vars.ShouldSplitAtThisPos(current.chapter, current.act, vars.gameTimerIsPaused.Changed, current.x, current.y, current.z) && vars.splitsLockTimer.ElapsedMilliseconds > 10000){
+        vars.splitsLockTimer.Restart();
+        return true;
+    }
 
     return false;
 }
 
 reset {
-    if (vars.timePieceCount.Old == 0 && settings["settings_noResetIntro"] && version != "Undetected" && current.x > -2300f && current.x < -2000f && current.y > -2000f && current.y < -1750f){
-        return false;
-    }
-    return vars.timerState.Current == 0 && vars.timerState.Old == 1 
-        || settings["settings_ILMode"] && (vars.actTimerIsVisible.Current == 0 && vars.actTimerIsVisible.Old == 1 || vars.realActTime.Current < vars.realActTime.Old);
+    return (vars.timerState.Current == 0 && vars.timerState.Old == 1 
+        || settings["settings_ILMode"] && (vars.actTimerIsVisible.Current == 0 && vars.actTimerIsVisible.Old == 1 || vars.realActTime.Current < vars.realActTime.Old && vars.realActTime.Current == 0f))
+        && !(vars.timePieceCount.Old == 0 && settings["settings_noResetIntro"] && version != "Undetected" && current.x > -2300f && current.x < -2000f && current.y > -2000f && current.y < -1750f);
 }
 
 isLoading {

--- a/AHatInTime.asl
+++ b/AHatInTime.asl
@@ -99,8 +99,9 @@ init {
             "Would you like to change the current timing method to\nGame Time instead of Real Time?", 
             "LiveSplit | A Hat in Time Auto Splitter", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
 
-        if (message == DialogResult.Yes)
+        if (message == DialogResult.Yes){
             timer.CurrentTimingMethod = TimingMethod.GameTime;
+        }
     }
 
     switch (modules.First().ModuleMemorySize) {
@@ -186,10 +187,14 @@ start {
 }
 
 split {
+    if (vars.timerState.Current == 0){
+        return false;
+    }
+
     if (vars.timePieceCount.Current == vars.timePieceCount.Old + 1 && (settings["splits_tp_new"] || (version != "Undetected" && settings["manySplits_" + current.chapter + "_" + current.act + "_tp"])) ||
         vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && (settings["splits_tp_any"] || (version != "Undetected" && settings["manySplits_" + current.chapter + "_" + current.act + "_tp"]))||
         version != "Undetected" && vars.justGotTimePiece.Current == 1 && vars.justGotTimePiece.Old == 0 && current.chapter == 3 && vars.lastChapter == 5 && settings["splits_tp_std"] ||
-        current.chapter == 97 && old.chapter != 97 && settings["splits_dwbth"] ||
+        version != "Undetected" && current.chapter == 97 && old.chapter != 97 && settings["splits_dwbth"] ||
         vars.splitInLoadScreen && vars.gameTimerIsPaused.Current == 1 && vars.gameTimerIsPaused.Old == 0){
             return true;
         }


### PR DESCRIPTION
* Added a new settings tree, "Detailed Splits", with many customizable split options for all acts and time rifts, including time piece grabs, delayed time grabs, new checkpoints, position splits, act entries and more.

* The initial load of the auto splitter when the game is already open is now much faster.

* Renamed "Splits" settings tree to "Simple Splits" and added to it "Act Entries" as an option.

* Added a setting to avoid resetting when immediately going back to main menu when opening a new file.